### PR TITLE
Build both CJS and ESM versions of the library

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.16",
   "description": "Authenticate to CommunitySolidServer using its API",
   "homepage": "https://github.com/mrkvon/css-authn",
+  "type": "module",
   "repository": {
     "type": "git",
     "url": "https://github.com/mrkvon/css-authn.git"
@@ -14,14 +15,29 @@
     "community-solid-server"
   ],
   "license": "MIT",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "./dist/cjs/index.d.ts",
+  "exports": {
+    ".": {
+      "require": {
+        "default": "./dist/cjs/index.js",
+        "types": "./dist/cjs/index.d.ts"
+      },
+      "import": {
+        "default": "./dist/esm/index.js",
+        "types": "./dist/esm/index.d.ts"
+      }
+    }
+  },
   "files": [
     "dist",
     "src"
   ],
   "scripts": {
-    "build": "rm -rf dist && tsc",
+    "build:esm": "tsc --project tsconfig.esm.json",
+    "build:cjs": "tsc --project tsconfig.cjs.json",
+    "build": "rm -rf dist && yarn build:esm && yarn build:cjs",
     "prepublishOnly": "yarn build",
     "lint": "eslint --ext .ts",
     "lint:fix": "eslint --ext .ts --fix",

--- a/src/6.x.ts
+++ b/src/6.x.ts
@@ -4,7 +4,7 @@ import {
   createDpopHeader,
   generateDpopKeyPair,
 } from '@inrupt/solid-client-authn-core'
-import { toBase64 } from './utils'
+import { toBase64 } from './utils.js'
 
 // https://communitysolidserver.github.io/CommunitySolidServer/6.x/usage/client-credentials/#generating-a-token
 export const generateToken = async ({

--- a/src/7.x.ts
+++ b/src/7.x.ts
@@ -4,7 +4,7 @@ import {
   generateDpopKeyPair,
 } from '@inrupt/solid-client-authn-core'
 import tough from 'tough-cookie'
-import { toBase64 } from './utils'
+import { toBase64 } from './utils.js'
 
 type AccountHandles = {
   controls: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
-export * as v6 from './6.x'
-export * as v7 from './7.x'
+export * as v6 from './6.x.js'
+export * as v7 from './7.x.js'

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,16 +1,14 @@
 {
   "compilerOptions": {
-    "target": "esnext",
+    "target": "es5",
     "lib": ["esnext"],
-    "module": "commonjs",
     "declaration": true,
     "sourceMap": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
-    "noImplicitAny": true,
-    "outDir": "./dist"
+    "noImplicitAny": true
   },
-  "include": ["./src", "./test"]
+  "include": ["./src"]
 }

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "./dist/cjs"
+  }
+}

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "outDir": "./dist/esm"
+  }
+}


### PR DESCRIPTION
They get built into `./dist/cjs/` and `./dist/esm/`. Still not sure whether it all works properly.