### PR TITLE
chore(deps)!: upgrade @inrupt/solid-client-authn-core to v2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Setup tests with node:test runner. Usage: `yarn test` and `yarn test:watch`.
+- Setup tests with `node:test` runner. Usage: `yarn test` and `yarn test:watch`.
 - Add github workflows.
 
 ### Changed
 
+- **BREAKING CHANGE:**: Upgrade `@inrupt/solid-client-authn-core` to v2.  
+  Custom fetch is no longer supported.  
+  Drop support for Node v16. Supported Node versions are 18, 20, 22.
 - Switch from cookie to authorization header in `v7.createAccount`.
 
 ## [0.1.1] - 2025-03-26
@@ -33,7 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Refactor `v7.getAuthenticatedFetch` to use auth header instead of a cookie. This improves compatibility with browser. (90ac826c98b6d5316bb7bd36c7331e15943d6021)
-- **BREAKING CHANGE**: Remove default values from `v7.createAccount`. (cb0ba481fa0277448680c297af4c59d8901508dd)
+- **BREAKING CHANGE:** Remove default values from `v7.createAccount`. (cb0ba481fa0277448680c297af4c59d8901508dd)
 
 ## [0.0.16] - 2024-05-04
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "test:watch": "NODE_ENV=vitest node --import tsx --test --watch src/tests/*.spec.ts"
   },
   "dependencies": {
-    "@inrupt/solid-client-authn-core": "^1.17.5"
+    "@inrupt/solid-client-authn-core": "^2.4.1"
   },
   "devDependencies": {
     "@solid/community-server": "^7.1.7",

--- a/src/6.x.ts
+++ b/src/6.x.ts
@@ -41,18 +41,16 @@ const generateToken = async ({
   email,
   password,
   tokenName = 'my-token',
-  fetch: customFetch = globalThis.fetch,
 }: {
   provider: string
   email: string
   password: string
   tokenName?: string
-  fetch?: typeof globalThis.fetch
 }) => {
   // This assumes your server is started under http://localhost:3000/.
   // This URL can also be found by checking the controls in JSON responses when interacting with the IDP API,
   // as described in the Identity Provider section.
-  const response = await customFetch(
+  const response = await fetch(
     new URL('idp/credentials/', provider).toString(),
     {
       method: 'POST',
@@ -84,12 +82,10 @@ const requestAccessToken = async ({
   provider,
   id,
   secret,
-  fetch: customFetch = globalThis.fetch,
 }: {
   provider: string
   id: string
   secret: string
-  fetch?: typeof globalThis.fetch
 }) => {
   // A key pair is needed for encryption.
   // This function from `solid-client-authn` generates such a pair for you.
@@ -102,7 +98,7 @@ const requestAccessToken = async ({
   // http://localhost:3000/.well-known/openid-configuration
   // if your server is hosted at http://localhost:3000/.
   const tokenUrl = new URL('.oidc/token', provider).toString()
-  const response = await customFetch(tokenUrl, {
+  const response = await fetch(tokenUrl, {
     method: 'POST',
     headers: {
       // The header needs to be in base64 encoding.
@@ -133,17 +129,13 @@ const requestAccessToken = async ({
 const authenticateFetch = async ({
   dpopKey,
   accessToken,
-  fetch: customFetch = globalThis.fetch,
 }: {
   dpopKey: KeyPair
   accessToken: string
-  fetch?: typeof globalThis.fetch
 }) => {
   // The DPoP key needs to be the same key as the one used in the previous step.
   // The Access token is the one generated in the previous step.
-  const authFetch = await buildAuthenticatedFetch(customFetch, accessToken, {
-    dpopKey,
-  })
+  const authFetch = buildAuthenticatedFetch(accessToken, { dpopKey })
   // authFetch can now be used as a standard fetch function that will authenticate as your WebID.
   return authFetch
 }
@@ -152,30 +144,25 @@ export const getAuthenticatedFetch = async ({
   provider,
   email,
   password,
-  fetch: customFetch = globalThis.fetch,
 }: {
   provider: string
   email: string
   password: string
-  fetch?: typeof globalThis.fetch
 }) => {
   const { id, secret } = await generateToken({
     provider,
     email,
     password,
-    fetch: customFetch,
   })
   const { dpopKey, accessToken } = await requestAccessToken({
     provider,
     id,
     secret,
-    fetch: customFetch,
   })
 
   const authenticatedFetch = authenticateFetch({
     dpopKey,
     accessToken,
-    fetch: customFetch,
   })
 
   return authenticatedFetch

--- a/yarn.lock
+++ b/yarn.lock
@@ -2167,11 +2167,6 @@
   resolved "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz#a5417ae8427873f1dd08b70b3574b453e67b5f7f"
   integrity sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==
 
-"@fastify/busboy@^2.0.0":
-  version "2.1.0"
-  resolved "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.0.tgz#0709e9f4cb252351c609c6e6d8d6779a8d25edff"
-  integrity sha512-+KpH+QxZU7O4675t3mnkQKcZZg56u+K/Ct2K+N2AZYNVK8kyeo/bI18tI8aPm3tvNNRyTWfj6s5tnGNlcbQRsA==
-
 "@humanwhocodes/config-array@^0.11.14":
   version "0.11.14"
   resolved "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz#d78e481a039f7566ecc9660b4ea7fe6b1fec442b"
@@ -2191,23 +2186,14 @@
   resolved "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.2.tgz#d9fae00a2d5cb40f92cfe64b47ad749fbc38f917"
   integrity sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==
 
-"@inrupt/solid-client-authn-core@^1.17.5":
-  version "1.17.5"
-  resolved "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-1.17.5.tgz#fc1eb1a3f4558bc924934862b5f1865a4f50dd4e"
-  integrity sha512-g3WShcPAqGuarPYlw12vUCo+et4elQLI+WYcHkCHGLuQQFF73r2iTicuKpkydQdIrZ5AZgxhwr315jmkx/vcFQ==
+"@inrupt/solid-client-authn-core@^2.4.1":
+  version "2.4.1"
+  resolved "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-2.4.1.tgz#1cb4aab72ae367c2885ded98dae429b707005bb4"
+  integrity sha512-px0O5m4xTIgV/uFmfR956F+ZVBaoCzpRlaGjThhgPrUqy5obI6X4A/qXv3Cil6Hkmc2Ip/whiq77OQUmRbvYog==
   dependencies:
-    "@inrupt/universal-fetch" "^1.0.1"
     events "^3.3.0"
-    jose "^4.15.4"
-    uuid "^9.0.1"
-
-"@inrupt/universal-fetch@^1.0.1":
-  version "1.0.3"
-  resolved "https://registry.npmjs.org/@inrupt/universal-fetch/-/universal-fetch-1.0.3.tgz#b13cedc95e6e7adbd6b749846ab0c7e49e918f9c"
-  integrity sha512-AP/nMOuuKvR2YoQkdS77ntuuq5ZYDGStI8Uirp1MCsyPSoBLyNnRjMLjlGqIlaC+5Xp7TYZJ9z/Kl2uUEpXUFw==
-  dependencies:
-    node-fetch "^2.6.7"
-    undici "^5.19.1"
+    jose "^5.1.3"
+    uuid "^11.1.0"
 
 "@ioredis/commands@^1.1.1":
   version "1.2.0"
@@ -4192,11 +4178,6 @@ jose@^4.15.2:
   resolved "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz#9b68eda29e9a0614c042fa29387196c7dd800100"
   integrity sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==
 
-jose@^4.15.4:
-  version "4.15.4"
-  resolved "https://registry.npmjs.org/jose/-/jose-4.15.4.tgz#02a9a763803e3872cf55f29ecef0dfdcc218cc03"
-  integrity sha512-W+oqK4H+r5sITxfxpSU+MMdr/YSWGvgZMQDIsNoBDGGy4i7GBPTtvFKibQzW06n3U3TqHjhvBJsirShsEJ6eeQ==
-
 jose@^5.1.3, jose@^5.9.6:
   version "5.10.0"
   resolved "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz#c37346a099d6467c401351a9a0c2161e0f52c4be"
@@ -4563,7 +4544,7 @@ neo-async@^2.6.2:
   resolved "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
-node-fetch@^2.6.7, node-fetch@^2.7.0:
+node-fetch@^2.7.0:
   version "2.7.0"
   resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
   integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
@@ -5508,13 +5489,6 @@ undici-types@~6.21.0:
   resolved "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz#691d00af3909be93a7faa13be61b3a5b50ef12cb"
   integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
 
-undici@^5.19.1:
-  version "5.28.3"
-  resolved "https://registry.npmjs.org/undici/-/undici-5.28.3.tgz#a731e0eff2c3fcfd41c1169a869062be222d1e5b"
-  integrity sha512-3ItfzbrhDlINjaP0duwnNsKpDQk3acHI3gVJ1z4fmwMK31k5G9OVIAMLSIaP6w4FaGkaAkN6zaQO9LUvZ1t7VA==
-  dependencies:
-    "@fastify/busboy" "^2.0.0"
-
 universalify@^2.0.0:
   version "2.0.1"
   resolved "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz#168efc2180964e6386d061e094df61afe239b18d"
@@ -5546,6 +5520,11 @@ util-deprecate@^1.0.1:
   version "1.0.2"
   resolved "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
+
+uuid@^11.1.0:
+  version "11.1.0"
+  resolved "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz#9549028be1753bb934fc96e2bca09bb4105ae912"
+  integrity sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==
 
 uuid@^9.0.0, uuid@^9.0.1:
   version "9.0.1"


### PR DESCRIPTION
BREAKING CHANGE:
- Remove custom fetch parameter from all methods; now uses global `fetch`.
- Drop support for Node v16. Supported versions are now 18, 20, 22.